### PR TITLE
Fix the Cornucopia ability potentially updating plant graphics on the wrong map

### DIFF
--- a/1.5/Source/AlphaBooks/Abilities/CompAbilityCornucopia.cs
+++ b/1.5/Source/AlphaBooks/Abilities/CompAbilityCornucopia.cs
@@ -34,7 +34,7 @@ namespace AlphaBooks
                     int num = (int)((1f - plant.Growth) * plant.def.plant.growDays);
                     plant.Age += num;
                     plant.Growth = 1f;
-                    Find.CurrentMap.mapDrawer.SectionAt(plant.Position).RegenerateAllLayers();
+                    plant.Map.mapDrawer.SectionAt(plant.Position).RegenerateAllLayers();
 
                 }
                 


### PR DESCRIPTION
The cornucopia ability was updating the plant graphics on the currently visible map rather than the map the plant was on. This could end up in a situation where a fully grown plant was looking like a freshly planted one.