### PR TITLE
Only apply book outcome if the pawn finished reading the book

### DIFF
--- a/1.5/Source/AlphaBooks/Harmony/JobDriver_Reading_ReadBook.cs
+++ b/1.5/Source/AlphaBooks/Harmony/JobDriver_Reading_ReadBook.cs
@@ -23,7 +23,7 @@ namespace AlphaBooks
             {
                 BookDefModExtension extension = __instance.Book.def.GetModExtension<BookDefModExtension>();
 
-                if (extension?.readResults.NullOrEmpty() == false)
+                if (extension?.readResults.NullOrEmpty() == false && __instance.pawn.jobs.curDriver.ticksLeftThisToil <= 0)
                 {
                     foreach(BookReadResults result in extension.readResults)
                     {


### PR DESCRIPTION
Currently, the book will always apply its effect on any pawn that was reading the book for any amount of time, so it's possible to speed up the process by just cancelling the order. On top of that, there currently isn't a way to stop a pawn from using the book once they started reading it.

The change here will only apply the reading outcome if the pawn has fully finished reading the book by checking if pawn's current `JobDriver.ticksLeftThisToil` is 0 (or less, just in case).

I believe that `pawn.jobs.curDriver` should be the same as the toil we're adding this finish action to based on vanilla code - specifically, given that in vanilla `Toils_LayDown.SelfShutdown` and `Toils_LayDown.ActivityDormant` both make the same assumption in their finish actions. I've tested it as well and it seemed fine on my end.